### PR TITLE
libpspvram: fix "lib/include is not a directory"

### DIFF
--- a/libpspvram/Makefile
+++ b/libpspvram/Makefile
@@ -33,6 +33,7 @@ PSPDIR=$(shell psp-config --psp-prefix)
 include $(PSPSDK)/lib/build.mak
 
 install: pspvalloc pspvram
+	@mkdir -p $(PSPDIR)/include $(PSPDIR)/lib
 	@cp -v $(TARGET_LIB_VRAM) $(TARGET_LIB_VALLOC) $(PSPDIR)/lib
 	@cp -v *.h $(PSPDIR)/include
 	@echo "Done."


### PR DESCRIPTION
Example where it fails: https://aur.archlinux.org/packages/psp-libpspvram/
