### PR TITLE
Use parameterized binary names for tools

### DIFF
--- a/freetype/autogen.sh
+++ b/freetype/autogen.sh
@@ -28,9 +28,9 @@ fi
 
 cd builds/unix
 
-run aclocal -I .
-run libtoolize --copy
-run autoconf
+run ${ACLOCAL:-aclocal} -I .
+run ${LIBTOOLIZE:-libtoolize} --copy
+run ${AUTOCONF:-autoconf}
 
 chmod +x mkinstalldirs
 chmod +x install-sh


### PR DESCRIPTION
Okay...this is mainly for Mac OS X, which comes with an existing 'libtool' of NeXTSTEP but not GNU. Package manager like Homebrew will use the names 'glibtool/glibtoolize' instead of their canonical names in order to prevent conflicts. I think it is a better idea to use parameterized binary names to give it a chance on such systems.