### PR TITLE
Removed "exe" suffix from Makefiles since it breaks non-windows platforms

### DIFF
--- a/freetype/builds/compiler/psp-gcc.mk
+++ b/freetype/builds/compiler/psp-gcc.mk
@@ -14,7 +14,7 @@
 
 # Compiler command line name
 #
-CC       := psp-gcc.exe
+CC       := psp-gcc
 
 # The object file extension (for standard and static libraries).  This can be
 # .o, .tco, .obj, etc., depending on the platform.
@@ -67,6 +67,6 @@ ANSIFLAGS := -ansi -pedantic
 ifndef CLEAN_LIBRARY
   CLEAN_LIBRARY = $(DELETE) $(subst $(SEP),$(HOSTSEP),$(PROJECT_LIBRARY))
 endif
-LINK_LIBRARY = psp-ar.exe -r $@ $(OBJECTS_LIST)
+LINK_LIBRARY = psp-ar -r $@ $(OBJECTS_LIST)
 
 # EOF

--- a/freetype/builds/psp/psp-def.mk
+++ b/freetype/builds/psp/psp-def.mk
@@ -23,7 +23,7 @@ DELETE   := rm -f
 SEP      := /
 BUILD    := $(TOP_DIR)/builds/ps2
 PLATFORM := ps2
-CC       := psp-gcc.exe
+CC       := psp-gcc
 
 COMPILER_SEP := $(SEP)
 


### PR DESCRIPTION
This takes care of the first sub-issue reported in #21, i.e.:
> Executable names like "psp-gcc.exe" & "psp-ar.exe" will not work in non-emulated POSIX environments, e.g., OS X in my case, due to the ".exe" suffix.