### PR TITLE
Add change from psplibraries to pspgl

### DIFF
--- a/pspgl/glLockArraysEXT.c
+++ b/pspgl/glLockArraysEXT.c
@@ -1,3 +1,4 @@
+#include <psptypes.h>
 #include <stdlib.h>
 #include <malloc.h>
 #include <pspge.h>

--- a/pspgl/pspgl_dlist.c
+++ b/pspgl/pspgl_dlist.c
@@ -1,3 +1,4 @@
+#include <psptypes.h>
 #include <stdlib.h>
 #include <string.h>
 #include <malloc.h>

--- a/pspgl/pspgl_vidmem.c
+++ b/pspgl/pspgl_vidmem.c
@@ -1,3 +1,4 @@
+#include <psptypes.h>
 #include <stdlib.h>
 #include <string.h>
 #include <pspdisplay.h>


### PR DESCRIPTION
As mentioned in https://github.com/pspdev/psplibraries/pull/66#pullrequestreview-417071965 the installation script for pspgl in psplibraries makes a change to the pspgl code which should be in this repo anyway. I'll make a PR for psplibraries as well which makes this no longer apply.