### PR TITLE
libvorbis: Fix crash by not trying to invoke close_func callback if not available

### DIFF
--- a/libvorbis/lib/vorbisfile.c
+++ b/libvorbis/lib/vorbisfile.c
@@ -709,7 +709,10 @@ int ov_clear(OggVorbis_File *vf){
     if(vf->serialnos)_ogg_free(vf->serialnos);
     if(vf->offsets)_ogg_free(vf->offsets);
     ogg_sync_clear(&vf->oy);
-    if(vf->datasource)(vf->callbacks.close_func)(vf->datasource);
+    if(vf->datasource && vf->callbacks.close_func)
+    {
+      (vf->callbacks.close_func)(vf->datasource);
+    }
     memset(vf,0,sizeof(*vf));
   }
 #ifdef DEBUG_LEAKS


### PR DESCRIPTION
This would happen when trying to call `Mix_FreeMusic` with SDL_mixer. When the music is loaded with `Mix_LoadMUS`, SDL_mixer doesn't configure that `close_func` callback.

The fix here also exists in the latest version of libvorbis: https://github.com/xiph/vorbis/blob/master/lib/vorbisfile.c#L977