### PR TITLE
MSYS make thinks install is always up to date

### DIFF
--- a/libmad/Makefile
+++ b/libmad/Makefile
@@ -1,6 +1,7 @@
 all: 
 	$(MAKE) -C src
-install:
+
+install: all
 	$(MAKE) -C src install
 
 clean:


### PR DESCRIPTION
Don't understand why but running `make install` would always say that it's up to date without even running the command.